### PR TITLE
Creates nginx container and config for footprints proxy that can vali…

### DIFF
--- a/build-bsg.sh
+++ b/build-bsg.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+if test "$#" -lt 1; then
+  echo "Usage: $0 <applicaiton name> <environment name>"
+  echo
+  echo "e.g.  $0 footprints-tiles dev"
+  exit 1
+fi
+
+APP_NAME=$1
+ENV_NAME=$2
+
+./scripts/build_deps.sh
+
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+. scripts/common.sh
+. scripts/build_proxy_base_image.sh
+echo "sha1: $dockerfile_sha1"
+dockerfile_sha1=$(cat $proxy_base_dir/Dockerfile | openssl sha1 | sed 's/^.* //')
+
+docker tag -f proxy-base-image:$dockerfile_sha1 proxy-base-image:latest
+
+proxy_image_exists=$(docker images | grep "nginx-jwt-$APP_NAME\s*") || true
+
+docker build -t="nginx-jwt-$APP_NAME" --force-rm $proxy_base_dir/bsg/$APP_NAME
+docker tag -f nginx-jwt-$APP_NAME openwhere/nginx-jwt-$APP_NAME:$ENV_NAME
+docker push openwhere/nginx-jwt-$APP_NAME:$ENV_NAME

--- a/hosts/proxy/bsg/footprints-tiles/Dockerfile
+++ b/hosts/proxy/bsg/footprints-tiles/Dockerfile
@@ -1,0 +1,4 @@
+FROM proxy-base-image
+
+
+EXPOSE 80

--- a/hosts/proxy/bsg/footprints-tiles/nginx/conf/nginx.conf
+++ b/hosts/proxy/bsg/footprints-tiles/nginx/conf/nginx.conf
@@ -1,0 +1,72 @@
+env JWT_SECRET;
+
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    proxy_buffering    off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Scheme $scheme;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   Host $http_host;
+    proxy_redirect     off;
+    sendfile on;
+    lua_package_path '/opt/openresty/nginx/lua/?.lua;;';
+
+    server {
+        listen 80;
+        server_name _;
+
+        location /elbhealth {
+            access_log off;
+            return 200;
+        }
+
+        location /api/scene/search {
+            access_by_lua '
+                local jwt = require("nginx-jwt")
+                jwt.auth()
+            ';
+            proxy_set_header Host tiles;
+            proxy_pass http://tiles:8080;
+        }
+
+        location /api/tile/service/footprints {
+            access_by_lua '
+                local jwt = require("nginx-jwt")
+                jwt.auth()
+            ';
+            proxy_set_header Host footprints;
+            proxy_pass http://footprints:8080;
+        }
+    }
+
+    server {
+        listen 80;
+        server_name "~^[abc]{1}\-tiles\..*$" "~^[abc]{1}\-tiles\-\w+\..*$";
+
+        location / {
+            access_by_lua '
+                local jwt = require("nginx-jwt")
+                jwt.auth()
+            ';
+            proxy_set_header Host tiles;
+            proxy_pass http://tiles:8080;
+        }
+    }
+
+    server {
+        listen 80;
+        server_name "~^[abc]{1}\-footprints\..*$" "~^[abc]{1}\-footprints\-\w+\..*$";
+
+        location /api/tile/service {
+            access_by_lua '
+                local jwt = require("nginx-jwt")
+                jwt.auth()
+            ';
+            proxy_set_header Host footprints;
+            proxy_pass http://footprints:8080;
+        }
+    }
+}


### PR DESCRIPTION
…date JWTs.  Instead of creating a container for each possible configuration this should eventually move to one container with the configuration supplied at run time but right now I could not get that approach working while still using the ENV directive in the nginx.conf which is needed to pass in the JWT signing key.