### PR TITLE
Explode DNS match to get rid of regex.  Add path for tiles and footpr…

### DIFF
--- a/hosts/proxy/bsg/footprints-tiles/nginx/conf/nginx.conf
+++ b/hosts/proxy/bsg/footprints-tiles/nginx/conf/nginx.conf
@@ -45,29 +45,27 @@ http {
 
     server {
         listen 80;
-        server_name "~^[abc]{1}\-tiles\..*$" "~^[abc]{1}\-tiles\-\w+\..*$";
+        server_name a-tiles.* b-tiles.* c-tiles.*;
 
         location / {
             access_by_lua '
                 local jwt = require("nginx-jwt")
                 jwt.auth()
             ';
-            proxy_set_header Host tiles;
-            proxy_pass http://tiles:8080;
+            proxy_pass http://tiles:80/tiles/;
         }
     }
 
     server {
         listen 80;
-        server_name "~^[abc]{1}\-footprints\..*$" "~^[abc]{1}\-footprints\-\w+\..*$";
+        server_name a-footprints.* b-footprints.* c-footprints.*;
 
-        location /api/tile/service {
+        location / {
             access_by_lua '
                 local jwt = require("nginx-jwt")
                 jwt.auth()
             ';
-            proxy_set_header Host footprints;
-            proxy_pass http://footprints:8080;
+            proxy_pass http://footprints:80/footprints/;
         }
     }
 }

--- a/nginx-jwt.lua
+++ b/nginx-jwt.lua
@@ -69,7 +69,7 @@ function M.auth(claim_specs)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
-    ngx.log(ngx.INFO, "JWT: " .. cjson.encode(jwt_obj))
+    --ngx.log(ngx.INFO, "JWT: " .. cjson.encode(jwt_obj))
 
     -- optionally require specific claims
     if claim_specs ~= nil then


### PR DESCRIPTION
…ints to work against new ECS services.  Stop printing the decoded JWT to the log.